### PR TITLE
Stabilize Empatica E4 streaming lifecycle and add gap detection tests

### DIFF
--- a/helper/muse_helper.py
+++ b/helper/muse_helper.py
@@ -46,16 +46,40 @@ class Muse():
                  enable_ppg = True
 
     ):
-        """Initialize
+        """Initialize the Muse interface with queue-based data sinks.
 
-        callback_eeg -- callback for eeg data, function(data, timestamps)
-        callback_control -- function(message)
-        callback_telemetry -- function(timestamp, battery, fuel_gauge,
-                                       adc_volt, temperature)
-
-        callback_acc -- function(timestamp, samples)
-        callback_gyro -- function(timestamp, samples)
-        - samples is a list of 3 samples, where each sample is [x, y, z]
+        Parameters
+        ----------
+        address : str
+            Bluetooth address of the Muse headset.
+        shared_eeg : multiprocessing.Queue
+            Queue used to deliver EEG samples to the consumer process.
+        shared_ppg : multiprocessing.Queue
+            Queue receiving photoplethysmography (PPG) samples.
+        shared_acc : multiprocessing.Queue
+            Queue receiving accelerometer samples.
+        shared_gyro : multiprocessing.Queue
+            Queue receiving gyroscope samples.
+        shared_tel : multiprocessing.Queue
+            Queue receiving telemetry updates.
+        shared_con : multiprocessing.Queue
+            Queue receiving control channel messages.
+        synchronized_start_time : float
+            Wall-clock reference for aligning device timestamps.
+        backend : str, optional
+            BLE backend identifier (``'bgapi'``, ``'gatt'``, ``'bleak'``, or ``'bluemuse'``).
+        interface : str, optional
+            Identifier for the BLE adapter interface when required by the backend.
+        time_func : Callable, optional
+            Function used to obtain the local clock for timestamp alignment.
+        name : str, optional
+            Friendly name for logging purposes.
+        preset : str, optional
+            Optional preset profile to select after connecting.
+        disable_light : bool, optional
+            If ``True``, the LED is disabled after connecting.
+        enable_* : bool, optional
+            Flags controlling which sensor subscriptions are activated.
         """
         self.address = address
         self.name = name

--- a/streamer/stream_e4.py
+++ b/streamer/stream_e4.py
@@ -40,6 +40,7 @@ class StreamE4():
         self.queue = Queue()
         self.empatica_e4 = None
         self.root_output_folder = root_output_folder
+        self.process = None
         self.subscribed_streams = {
             "acc": False,
             "bvp": False,
@@ -64,7 +65,7 @@ class StreamE4():
         except Exception as e:
             logger.error(f"Connection failed: {e}")
 
-    def suscribe_to_data(self):
+    def subscribe_to_data(self):
         self.empatica_e4.suspend_streaming()
         try:
             if acc:
@@ -144,7 +145,7 @@ class StreamE4():
         if self.connected:
             logger.info("Reconnected successfully!")
             time.sleep(1)
-            self.suscribe_to_data()
+            self.subscribe_to_data()
             time.sleep(1)
             self.stream()
         else:
@@ -226,25 +227,52 @@ class StreamE4():
     def e4_streamer(self):
         self.connect()
         time.sleep(2)
-        self.suscribe_to_data()
+        self.subscribe_to_data()
         time.sleep(1)
         self.prepare_LSL_streaming()
         time.sleep(1)
         self.stream()
 
     def start_streaming(self):
-        process = Process(target=self.e4_streamer)
-        process.start()
-        result = self.queue.get()  # Wait until we get a result from the process
-        if result == 'connected':
-            self.connected_event.set()
-        process.join()
+        if self.streaming:
+            logger.warning("Streaming already in progress; start_streaming call ignored.")
+            return
+
+        self.connected_event.clear()
+        self.stop_signal = False
+        self.process = Process(target=self.e4_streamer)
+        self.process.start()
+
+        try:
+            result = self.queue.get(timeout=10)  # Wait until we get a result from the process
+            if result == 'connected':
+                self.connected_event.set()
+                self.streaming = True
+        except Empty:
+            logger.error("Timed out waiting for Empatica E4 connection confirmation.")
+
+        if not self.connected_event.is_set():
+            logger.error("Empatica E4 failed to report a successful connection.")
+            if self.process and self.process.is_alive():
+                self.process.terminate()
+                self.process.join(timeout=5)
+            self.process = None
+            self.streaming = False
 
     def stop_streaming(self):
         try:
-            self.empatica_e4.disconnect()
             self.stop_signal = True
+            if self.empatica_e4 is not None:
+                self.empatica_e4.disconnect()
         except Exception as e:
             logger.error(f"Error stopping the stream: {e}")
+        finally:
+            if self.process and self.process.is_alive():
+                self.process.join(timeout=5)
+                if self.process.is_alive():
+                    logger.warning("Empatica E4 streamer process did not terminate cleanly.")
+            self.process = None
+            self.streaming = False
+            self.connected_event.clear()
 
 

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,29 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+
+from data_processor import DataProcessor
+
+
+def test_detect_gaps_marks_time_gap_and_mutates_dataframe():
+    timestamps = pd.to_datetime([0, 1, 4, 5], unit='s')
+    df = pd.DataFrame({'signal': [1.0, 1.1, 1.2, 1.3]}, index=timestamps)
+    processor = DataProcessor(folder_path="/tmp")
+
+    gaps = processor.detect_gaps(df, gap_threshold=2, nan_sequence_threshold=2)
+
+    assert gaps.tolist() == [False, False, True, False]
+    assert df.iloc[2].isna().all()
+
+
+def test_detect_gaps_flags_long_nan_sequences():
+    timestamps = pd.RangeIndex(start=0, stop=6, step=1)
+    df = pd.DataFrame({'signal': [1.0, np.nan, np.nan, np.nan, 2.0, 3.0]}, index=timestamps)
+    processor = DataProcessor(folder_path="/tmp")
+
+    gaps = processor.detect_gaps(df, gap_threshold=2, nan_sequence_threshold=2)
+
+    expected = [False, True, True, True, False, False]
+    assert gaps.tolist() == expected
+    assert df['signal'].isna().tolist() == [False, True, True, True, False, False]


### PR DESCRIPTION
## Summary
- rename the Empatica subscription helper to `subscribe_to_data` and harden start/stop lifecycle management
- clarify Muse helper constructor docs to describe the queue-based integration surface
- add pytest coverage for `DataProcessor.detect_gaps`, including guards when numpy/pandas are unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee133bf95c832488ae92448c6484bc