### PR TITLE
Use event-driven readiness for recorder startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -208,7 +208,10 @@ def start_recording(state: AppState) -> None:
     recorder = StreamRecorder(state.root_output_folder)
     thread = threading.Thread(target=recorder.record_streams)
     thread.start()
-    time.sleep(5)
+    if not recorder.started_event.wait(timeout=10):
+        warning = "Recorder failed to report readiness within 10 seconds."
+        print(f"{warning}\n")
+        logger.critical(warning)
     state.recorder = recorder
     state.recorder_thread = thread
 

--- a/recorder/stream_recorder.py
+++ b/recorder/stream_recorder.py
@@ -47,9 +47,10 @@ class StreamRecorder:
         self.backoff_limit = backoff_limit  # Maximum backoff time in seconds
         self.backoff_times = {}  # Dictionary to track backoff times for each stream
         self.stream_update_interval = 2.0
-        self.stream_update_thread = threading.Thread(target=self.update_streams)
-        self.disconnect_handler_thread = threading.Thread(target=self.handle_disconnected_streams_thread)
+        self.stream_update_thread = None
+        self.disconnect_handler_thread = None
         self.disconnected_streams = set()
+        self.started_event = threading.Event()
 
         # Initialize the buffers and locks for the predefined stream types
         for key in self.stream_sample_rates.keys():
@@ -373,62 +374,82 @@ class StreamRecorder:
         return [last_timestamp + i * interval for i in range(1, count + 1)]
 
     def record_streams(self):
-        self.streams = self.check_streams()
-        self.stream_update_thread.start()
-        self.disconnect_handler_thread.start()  # Start the disconnection handler thread
+        try:
+            self.streams = self.check_streams()
+            self.stream_update_thread = threading.Thread(
+                target=self.update_streams,
+                name="StreamRecorderUpdate",
+                daemon=True,
+            )
+            self.disconnect_handler_thread = threading.Thread(
+                target=self.handle_disconnected_streams_thread,
+                name="StreamRecorderReconnect",
+                daemon=True,
+            )
+            self.stream_update_thread.start()
+            self.disconnect_handler_thread.start()  # Start the disconnection handler thread
 
-        miss_count = {}
-        self.last_received_timestamps = {}
-        self.nominal_srates = {stream_id: stream.nominal_srate() for stream_id, stream in self.streams.items()}
-        disconnection_times = {}
+            miss_count = {}
+            self.last_received_timestamps = {}
+            self.nominal_srates = {stream_id: stream.nominal_srate() for stream_id, stream in self.streams.items()}
+            disconnection_times = {}
 
-        for stream_id, stream in self.streams.items():
-            self.last_received_timestamps[stream_id] = None
-            inlet = StreamInlet(stream)
-            self.stream_inlets[stream_id] = inlet
-            self.connected[stream_id] = True
-            logger.info(f"Stream Connected: {stream_id}")
-            output_file = f"{self.output_folder}/{stream_id}.h5"
-            self.output_files[stream_id] = output_file
-            miss_count[stream_id] = 0
+            for stream_id, stream in self.streams.items():
+                self.last_received_timestamps[stream_id] = None
+                inlet = StreamInlet(stream)
+                self.stream_inlets[stream_id] = inlet
+                self.connected[stream_id] = True
+                logger.info(f"Stream Connected: {stream_id}")
+                output_file = f"{self.output_folder}/{stream_id}.h5"
+                self.output_files[stream_id] = output_file
+                miss_count[stream_id] = 0
 
-        while not self.stop_signal:
-            for stream_id, inlet in self.stream_inlets.items():
-                sample = inlet.pull_sample(timeout=0.0)
-                if sample[0] is None:
-                    miss_count[stream_id] = miss_count.get(stream_id) + 1
-                else:
-                    miss_count[stream_id] = 0
+            self.started_event.set()
 
-                # Check for disconnect using the provided method
-                self.check_disconnect(stream_id, miss_count)
+            while not self.stop_signal:
+                for stream_id, inlet in self.stream_inlets.items():
+                    sample = inlet.pull_sample(timeout=0.0)
+                    if sample[0] is None:
+                        miss_count[stream_id] = miss_count.get(stream_id) + 1
+                    else:
+                        miss_count[stream_id] = 0
 
-                # If a stream is disconnected, add it to the set of disconnected streams
-                if not self.connected[stream_id]:
-                    self.disconnected_streams.add(stream_id)
+                    # Check for disconnect using the provided method
+                    self.check_disconnect(stream_id, miss_count)
 
-            for stream_id, inlet in self.stream_inlets.items():
-                if self.connected[stream_id]:
-                    samples, sample_timestamps = inlet.pull_chunk(timeout=0.1)
-                    if samples:
-                        self.save_to_h5(stream_id, samples, sample_timestamps)
-                        self.last_received_timestamps[stream_id] = sample_timestamps[-1]
-                    elif stream_id in disconnection_times:
-                        # Handle disconnection upon reconnection
-                        disconnection_duration = local_clock() - disconnection_times[stream_id]
-                        self.handle_disconnection(stream_id, disconnection_duration)
-                        del disconnection_times[stream_id]
-                else:
-                    disconnection_times[stream_id] = local_clock()
+                    # If a stream is disconnected, add it to the set of disconnected streams
+                    if not self.connected[stream_id]:
+                        self.disconnected_streams.add(stream_id)
 
-            time.sleep(0.1)
+                for stream_id, inlet in self.stream_inlets.items():
+                    if self.connected[stream_id]:
+                        samples, sample_timestamps = inlet.pull_chunk(timeout=0.1)
+                        if samples:
+                            self.save_to_h5(stream_id, samples, sample_timestamps)
+                            self.last_received_timestamps[stream_id] = sample_timestamps[-1]
+                        elif stream_id in disconnection_times:
+                            # Handle disconnection upon reconnection
+                            disconnection_duration = local_clock() - disconnection_times[stream_id]
+                            self.handle_disconnection(stream_id, disconnection_duration)
+                            del disconnection_times[stream_id]
+                    else:
+                        disconnection_times[stream_id] = local_clock()
+
+                time.sleep(0.1)
+        except Exception:
+            logger.error("StreamRecorder failed to start streaming threads", exc_info=True)
+            self.started_event.set()
+            raise
 
     def stop(self):
         self.stop_signal = True
+        self.started_event.set()
 
         # Signal threads to stop
-        self.stream_update_thread.join()
-        self.disconnect_handler_thread.join()
+        if self.stream_update_thread:
+            self.stream_update_thread.join()
+        if self.disconnect_handler_thread:
+            self.disconnect_handler_thread.join()
 
         # Save datasets
         self.save_datasets()

--- a/tests/test_stream_recorder.py
+++ b/tests/test_stream_recorder.py
@@ -1,0 +1,35 @@
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("h5py")
+pytest.importorskip("mne")
+pytest.importorskip("numpy")
+pytest.importorskip("pandas")
+
+from recorder.stream_recorder import StreamRecorder
+
+
+def test_stream_recorder_signals_start(tmp_path, monkeypatch):
+    recorder = StreamRecorder(str(tmp_path))
+
+    # Avoid interacting with real LSL streams during the test.
+    monkeypatch.setattr(recorder, "check_streams", lambda: {})
+
+    def _idle_worker():
+        while not recorder.stop_signal:
+            time.sleep(0.01)
+
+    monkeypatch.setattr(recorder, "update_streams", _idle_worker)
+    monkeypatch.setattr(recorder, "handle_disconnected_streams_thread", _idle_worker)
+
+    thread = threading.Thread(target=recorder.record_streams, daemon=True)
+    thread.start()
+
+    assert recorder.started_event.wait(timeout=1.0)
+
+    recorder.stop()
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary
- replace the CLI's recorder startup sleep with a readiness event wait
- refactor `StreamRecorder` to create worker threads lazily, expose a started event, and guard thread shutdown
- add a smoke test for the recorder's readiness signal and package the recorder module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee453b22f883249cf4320d372f9cc7