### PR TITLE
Platform v2 (PR-1): device-manager core + FastAPI API + web UI scaffold

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
         # The pinned dev stack (numpy 2.4 / pandas 3.0 / scipy 1.17) ships wheels for
         # 3.11+ only — there is no cp310 wheel for these versions, so 3.10 is excluded.
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,8 +37,11 @@ jobs:
           python -m pip install -r requirements-dev.txt
 
       - name: Unit tests + coverage (excludes process-spawning integration tests)
+        # Use `python -m pytest` (not bare `pytest`) so the interpreter is the one pip
+        # installed the plugins into — otherwise the runner's pytest may lack pytest-cov
+        # and abort with a usage error (exit 4) on --cov.
         run: |
-          pytest -m "not integration" \
+          python -m pytest -m "not integration" \
             --cov=streamer --cov=recorder --cov=helper --cov=viewer --cov=data_processor \
             --cov-report=term-missing --cov-report=xml
 
@@ -46,7 +49,7 @@ jobs:
         # Run WITHOUT coverage: coverage + multiprocessing deadlocks on this interpreter.
         # The autouse reaper fixture in tests/conftest.py terminates stray child processes
         # after each test, so the session exits cleanly (no atexit join hang).
-        run: timeout 240 pytest -m "integration"
+        run: timeout 240 python -m pytest -m "integration"
 
       - name: Upload coverage.xml
         if: always()

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI web layer for the StreamSense platform."""

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,103 @@
+"""FastAPI application exposing the DeviceManager over REST + WebSocket.
+
+REST endpoints are declared as sync `def` so FastAPI runs the (blocking) device calls in
+a worker thread, keeping the event loop free for the WebSocket. The WebSocket bridges
+DeviceManager events into the asyncio loop via ``loop.call_soon_threadsafe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+
+from core import DeviceManager, DeviceManagerError
+
+
+class DiscoverRequest(BaseModel):
+    types: Optional[List[str]] = None
+
+
+def create_app(manager: Optional[DeviceManager] = None) -> FastAPI:
+    app = FastAPI(title="StreamSense Platform API", version="2.0.0-dev")
+    app.state.manager = manager or DeviceManager()
+
+    def mgr() -> DeviceManager:
+        return app.state.manager
+
+    @app.exception_handler(DeviceManagerError)
+    async def _dm_error(_request, exc: DeviceManagerError):
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    @app.get("/api/health")
+    def health():
+        return {"status": "ok", "ts": time.time()}
+
+    @app.get("/api/devices")
+    def list_devices():
+        return [d.to_dict() for d in mgr().devices.values()]
+
+    @app.post("/api/discover")
+    def discover(req: DiscoverRequest):
+        return [d.to_dict() for d in mgr().discover(req.types)]
+
+    @app.post("/api/devices/{device_id}/connect")
+    def connect(device_id: str):
+        ok = mgr().connect(device_id)
+        return {"ok": ok, "device": mgr().devices[device_id].to_dict()}
+
+    @app.post("/api/devices/{device_id}/disconnect")
+    def disconnect(device_id: str):
+        ok = mgr().disconnect(device_id)
+        return {"ok": ok, "device": mgr().devices[device_id].to_dict()}
+
+    @app.post("/api/recording/start")
+    def start_recording():
+        ok = mgr().start_recording()
+        return {"ok": ok, "recording": mgr().recording.to_dict()}
+
+    @app.post("/api/recording/stop")
+    def stop_recording():
+        ok = mgr().stop_recording()
+        return {"ok": ok, "recording": mgr().recording.to_dict()}
+
+    @app.get("/api/status")
+    def status():
+        return mgr().get_status().to_dict()
+
+    @app.get("/api/streams")
+    def streams():
+        return {"streams": mgr().list_streams()}
+
+    @app.websocket("/ws")
+    async def ws(websocket: WebSocket):
+        await websocket.accept()
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def listener(event: dict) -> None:
+            # Called from device/recorder threads -> hop back onto the event loop.
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+        mgr().add_listener(listener)
+        try:
+            await websocket.send_json(
+                {"type": "status", "payload": mgr().get_status().to_dict(), "ts": time.time()}
+            )
+            while True:
+                event = await queue.get()
+                await websocket.send_json(event)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            mgr().remove_listener(listener)
+
+    return app
+
+
+# Module-level app for `uvicorn api.app:app`
+app = create_app()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,25 @@
+"""StreamSense platform core (framework-agnostic).
+
+This package contains the UI-independent device-management logic. It must NOT import
+FastAPI or any hardware library at module load time; hardware imports live inside drivers
+and are performed lazily so the core imports and unit-tests cleanly in a headless CI.
+"""
+
+from .models import (
+    DeviceType,
+    ConnectionState,
+    DeviceInfo,
+    RecordingState,
+    SystemStatus,
+)
+from .device_manager import DeviceManager, DeviceManagerError
+
+__all__ = [
+    "DeviceType",
+    "ConnectionState",
+    "DeviceInfo",
+    "RecordingState",
+    "SystemStatus",
+    "DeviceManager",
+    "DeviceManagerError",
+]

--- a/core/device_manager.py
+++ b/core/device_manager.py
@@ -1,0 +1,248 @@
+"""Framework-agnostic device manager for the StreamSense platform.
+
+Owns device state, connection lifecycle, and recording. Emits events to registered
+listeners (the API layer bridges these to a WebSocket). Contains no FastAPI imports and
+no eager hardware imports.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from .models import (
+    DeviceType, ConnectionState, DeviceInfo, RecordingState, SystemStatus,
+)
+from .drivers import DeviceDriver, default_drivers
+
+logger = logging.getLogger("core.device_manager")
+
+Listener = Callable[[dict], None]
+
+
+class DeviceManagerError(Exception):
+    pass
+
+
+def _now_clock() -> float:
+    """Synchronized session clock; prefer pylsl.local_clock, fall back to time.time."""
+    try:
+        from pylsl import local_clock  # lazy
+        return local_clock()
+    except Exception:
+        return time.time()
+
+
+class DeviceManager:
+    def __init__(
+        self,
+        drivers: Optional[Dict[DeviceType, DeviceDriver]] = None,
+        output_root: Optional[str] = None,
+        recorder_factory: Optional[Callable[[str], object]] = None,
+    ):
+        self.drivers: Dict[DeviceType, DeviceDriver] = drivers or default_drivers()
+        self.output_root = output_root
+        self._recorder_factory = recorder_factory  # (output_folder) -> recorder
+        self.devices: Dict[str, DeviceInfo] = {}
+        self._streamers: Dict[str, object] = {}
+        self._recorder = None
+        self._recorder_thread: Optional[threading.Thread] = None
+        self.recording = RecordingState()
+        self._lock = threading.RLock()
+        self._listeners: List[Listener] = []
+        self.sync_time = _now_clock()
+
+    # ----- events ------------------------------------------------------------
+    def add_listener(self, cb: Listener) -> None:
+        self._listeners.append(cb)
+
+    def remove_listener(self, cb: Listener) -> None:
+        if cb in self._listeners:
+            self._listeners.remove(cb)
+
+    def _emit(self, event_type: str, payload: dict) -> None:
+        event = {"type": event_type, "payload": payload, "ts": time.time()}
+        for cb in list(self._listeners):
+            try:
+                cb(event)
+            except Exception:  # a bad listener must not break device logic
+                logger.exception("listener error")
+
+    def _emit_device(self, device: DeviceInfo) -> None:
+        self._emit("device_update", device.to_dict())
+
+    # ----- discovery ---------------------------------------------------------
+    def discover(self, types: Optional[List[str]] = None) -> List[DeviceInfo]:
+        wanted = self._resolve_types(types)
+        discovered: List[DeviceInfo] = []
+        for dtype in wanted:
+            driver = self.drivers.get(dtype)
+            if driver is None or not driver.live:
+                continue
+            ok, reason = driver.available()
+            if not ok:
+                self._emit("log", {"level": "warning",
+                                   "message": f"{dtype.value} unavailable: {reason}"})
+                continue
+            try:
+                found = driver.discover()
+            except Exception as exc:
+                logger.exception("discovery failed for %s", dtype)
+                self._emit("log", {"level": "error",
+                                   "message": f"{dtype.value} discovery error: {exc}"})
+                continue
+            for dev in found:
+                with self._lock:
+                    self.devices[dev.id] = dev
+                discovered.append(dev)
+                self._emit_device(dev)
+        return discovered
+
+    # ----- connection --------------------------------------------------------
+    def connect(self, device_id: str, timeout: int = 15) -> bool:
+        device = self._require_device(device_id)
+        driver = self.drivers[device.type]
+        if not driver.live:
+            raise DeviceManagerError(f"{device.type.value} is import-only; cannot connect live")
+        if device.state == ConnectionState.CONNECTED:
+            return True
+
+        device.state = ConnectionState.CONNECTING
+        self._emit_device(device)
+        try:
+            streamer = driver.create_streamer(device, self._ensure_output_folder(), self.sync_time)
+            ok = streamer.start_streaming(timeout=timeout)
+        except Exception as exc:
+            logger.exception("connect failed for %s", device_id)
+            device.state = ConnectionState.ERROR
+            device.detail = str(exc)
+            self._emit_device(device)
+            return False
+
+        if ok:
+            with self._lock:
+                self._streamers[device_id] = streamer
+            device.state = ConnectionState.CONNECTED
+            self._emit_device(device)
+            return True
+
+        device.state = ConnectionState.ERROR
+        device.detail = "start_streaming timed out / failed"
+        self._emit_device(device)
+        return False
+
+    def disconnect(self, device_id: str) -> bool:
+        device = self._require_device(device_id)
+        device.state = ConnectionState.DISCONNECTING
+        self._emit_device(device)
+        streamer = self._streamers.pop(device_id, None)
+        try:
+            if streamer is not None:
+                streamer.stop_streaming()
+        except Exception as exc:
+            logger.exception("disconnect error for %s", device_id)
+            device.state = ConnectionState.ERROR
+            device.detail = str(exc)
+            self._emit_device(device)
+            return False
+        device.state = ConnectionState.DISCONNECTED
+        device.signal_quality = None
+        self._emit_device(device)
+        return True
+
+    def disconnect_all(self) -> None:
+        if self.recording.active:
+            self.stop_recording()
+        for device_id in list(self._streamers.keys()):
+            self.disconnect(device_id)
+
+    # ----- recording ---------------------------------------------------------
+    def start_recording(self, timeout: int = 10) -> bool:
+        if self.recording.active:
+            return True
+        output_folder = self._ensure_output_folder()
+        recorder = self._make_recorder(output_folder)
+        thread = threading.Thread(target=recorder.record_streams, daemon=True)
+        thread.start()
+        started = recorder.started_event.wait(timeout=timeout)
+        if not started:
+            self._emit("log", {"level": "error",
+                               "message": "Recorder failed to start within timeout"})
+            return False
+        self._recorder = recorder
+        self._recorder_thread = thread
+        self.recording = RecordingState(
+            active=True,
+            session_id=datetime.now().strftime("%Y%m%d_%H%M%S"),
+            output_folder=output_folder,
+            started_at=time.time(),
+        )
+        self._emit("recording", self.recording.to_dict())
+        return True
+
+    def stop_recording(self) -> bool:
+        if not self.recording.active or self._recorder is None:
+            return True
+        try:
+            self._recorder.stop()
+        finally:
+            self._recorder = None
+            self._recorder_thread = None
+            self.recording = RecordingState(active=False)
+            self._emit("recording", self.recording.to_dict())
+        return True
+
+    # ----- queries -----------------------------------------------------------
+    def get_status(self) -> SystemStatus:
+        availability = {
+            dtype.value: {"available": (av := drv.available())[0], "reason": av[1],
+                          "live": drv.live}
+            for dtype, drv in self.drivers.items()
+        }
+        return SystemStatus(
+            devices=list(self.devices.values()),
+            recording=self.recording,
+            driver_availability=availability,
+        )
+
+    def list_streams(self) -> List[str]:
+        try:
+            from pylsl import resolve_streams  # lazy
+            return sorted({s.name() for s in resolve_streams(wait_time=1.0)})
+        except Exception:
+            return []
+
+    # ----- helpers -----------------------------------------------------------
+    def _resolve_types(self, types: Optional[List[str]]) -> List[DeviceType]:
+        if not types:
+            return [t for t, d in self.drivers.items() if d.live]
+        out = []
+        for t in types:
+            try:
+                out.append(DeviceType(t))
+            except ValueError:
+                raise DeviceManagerError(f"unknown device type: {t}")
+        return out
+
+    def _require_device(self, device_id: str) -> DeviceInfo:
+        device = self.devices.get(device_id)
+        if device is None:
+            raise DeviceManagerError(f"unknown device: {device_id}")
+        return device
+
+    def _ensure_output_folder(self) -> str:
+        if not self.output_root:
+            base = Path.home() / "StreamSense" / str(time.time()).replace(".", "_")
+            base.mkdir(parents=True, exist_ok=True)
+            self.output_root = str(base)
+        return self.output_root
+
+    def _make_recorder(self, output_folder: str):
+        if self._recorder_factory is not None:
+            return self._recorder_factory(output_folder)
+        from recorder.stream_recorder import StreamRecorder  # lazy
+        return StreamRecorder(output_folder)

--- a/core/drivers.py
+++ b/core/drivers.py
@@ -1,0 +1,152 @@
+"""Device drivers for the platform core.
+
+A driver knows how to (a) report whether its hardware/SW stack is *available* in the
+current environment, (b) *discover* devices, and (c) *create a streamer* for a device.
+
+Hardware libraries (pygatt, muselsl, bitalino, pyk4a, …) are imported **lazily inside
+methods** so that importing this module never requires any device SDK. This is what lets
+the core + API import and unit-test in a headless CI.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+from .models import DeviceType, DeviceInfo, ConnectionState
+
+logger = logging.getLogger("core.drivers")
+
+
+class DeviceDriver(ABC):
+    device_type: DeviceType
+    #: True if the driver supports live streaming; False for import-only (e.g. E4).
+    live: bool = True
+
+    @abstractmethod
+    def available(self) -> Tuple[bool, str]:
+        """Return (usable, human-reason). Must never raise."""
+
+    @abstractmethod
+    def discover(self) -> List[DeviceInfo]:
+        """Return discovered devices. Live drivers only."""
+
+    def create_streamer(self, device: DeviceInfo, output_folder: str, sync_time: float):
+        """Create (but do not start) a BaseStreamer for the device."""
+        raise NotImplementedError
+
+
+def _module_importable(module: str) -> Tuple[bool, str]:
+    try:
+        importlib.import_module(module)
+        return True, ""
+    except Exception as exc:  # ImportError or deeper init failure
+        return False, f"{module} unavailable: {exc}"
+
+
+# --------------------------------------------------------------------------- #
+# Real drivers (lazy hardware imports)
+# --------------------------------------------------------------------------- #
+class MuseDriver(DeviceDriver):
+    device_type = DeviceType.MUSE
+    live = True
+
+    def available(self) -> Tuple[bool, str]:
+        ok, reason = _module_importable("muselsl")
+        if not ok:
+            return False, reason
+        return _module_importable("pygatt")
+
+    def discover(self) -> List[DeviceInfo]:
+        from helper.find_devices import FindDevices  # lazy
+        muses, com_ports = FindDevices().find_muses_with_ports()
+        out: List[DeviceInfo] = []
+        n = min(len(com_ports), len(muses)) if com_ports and muses else 0
+        for i in range(n):
+            name, address = muses[i]
+            out.append(DeviceInfo(
+                id=f"muse:{address}", name=name, type=DeviceType.MUSE,
+                address=address, detail=f"interface={com_ports[n - i - 1]}",
+            ))
+        return out
+
+    def create_streamer(self, device: DeviceInfo, output_folder: str, sync_time: float):
+        from streamer.stream_muse import StreamMuse  # lazy
+        interface = (device.detail or "").replace("interface=", "") or None
+        return StreamMuse(
+            name=device.name, address=device.address, interface=interface,
+            root_output_folder=output_folder, synchronized_start_time=sync_time,
+        )
+
+
+class BitalinoDriver(DeviceDriver):
+    device_type = DeviceType.BITALINO
+    live = True
+
+    def available(self) -> Tuple[bool, str]:
+        return _module_importable("bitalino")
+
+    def discover(self) -> List[DeviceInfo]:
+        from helper.find_devices import FindDevices  # lazy
+        out: List[DeviceInfo] = []
+        for dev in FindDevices().scan_bluetooth():
+            name = dev.get("name", "")
+            if "bitalino" in name.lower():
+                addr = dev["address"]
+                out.append(DeviceInfo(
+                    id=f"bitalino:{addr}", name=name,
+                    type=DeviceType.BITALINO, address=addr,
+                ))
+        return out
+
+    def create_streamer(self, device: DeviceInfo, output_folder: str, sync_time: float):
+        from streamer.stream_bitalino import StreamBioTalino  # lazy
+        return StreamBioTalino(
+            mac_address=device.address, synchronized_start_time=sync_time,
+            root_output_folder=output_folder,
+        )
+
+
+class KinectDriver(DeviceDriver):
+    """Placeholder until PR-2 implements the pyk4a streamer."""
+
+    device_type = DeviceType.KINECT
+    live = True
+
+    def available(self) -> Tuple[bool, str]:
+        ok, reason = _module_importable("pyk4a")
+        if not ok:
+            return False, reason
+        return False, "Kinect streamer not yet implemented (planned in PR-2)"
+
+    def discover(self) -> List[DeviceInfo]:
+        return []
+
+
+class E4ImportDriver(DeviceDriver):
+    """E4 is import-only: Empatica withdrew the live streaming server.
+
+    This driver never streams live; it represents the E4 as a data source to be imported
+    from E4 Connect session archives (implemented in PR-3).
+    """
+
+    device_type = DeviceType.E4
+    live = False
+
+    def available(self) -> Tuple[bool, str]:
+        return False, "E4 real-time streaming withdrawn by Empatica; offline import only (PR-3)"
+
+    def discover(self) -> List[DeviceInfo]:
+        return []
+
+
+def default_drivers() -> dict:
+    """The drivers registered in production."""
+    return {
+        DeviceType.MUSE: MuseDriver(),
+        DeviceType.BITALINO: BitalinoDriver(),
+        DeviceType.KINECT: KinectDriver(),
+        DeviceType.E4: E4ImportDriver(),
+    }

--- a/core/models.py
+++ b/core/models.py
@@ -1,0 +1,76 @@
+"""Plain-dataclass models for the platform core.
+
+Deliberately uses stdlib dataclasses (not Pydantic) so the core has no web-stack
+dependency and unit-tests in the slim environment. The API layer defines its own
+serialization models.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from typing import Optional, List, Dict, Any
+
+
+class DeviceType(str, Enum):
+    MUSE = "muse"
+    BITALINO = "bitalino"
+    KINECT = "kinect"
+    E4 = "e4"  # import-only (Empatica withdrew the live streaming server)
+
+
+class ConnectionState(str, Enum):
+    DISCOVERED = "discovered"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DISCONNECTING = "disconnecting"
+    DISCONNECTED = "disconnected"
+    ERROR = "error"
+
+
+@dataclass
+class DeviceInfo:
+    """A device known to the manager (discovered and/or connected)."""
+
+    id: str
+    name: str
+    type: DeviceType
+    address: str = ""
+    state: ConnectionState = ConnectionState.DISCOVERED
+    # 0.0..1.0, or None when unknown. We never fabricate a value.
+    signal_quality: Optional[float] = None
+    detail: Optional[str] = None
+    # Names of the LSL streams this device publishes once connected.
+    streams: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["type"] = self.type.value
+        d["state"] = self.state.value
+        return d
+
+
+@dataclass
+class RecordingState:
+    active: bool = False
+    session_id: Optional[str] = None
+    output_folder: Optional[str] = None
+    started_at: Optional[float] = None  # epoch seconds
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SystemStatus:
+    devices: List[DeviceInfo]
+    recording: RecordingState
+    # type -> (available, reason) so the UI can show why a modality is unusable.
+    driver_availability: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "devices": [d.to_dict() for d in self.devices],
+            "recording": self.recording.to_dict(),
+            "driver_availability": self.driver_availability,
+        }

--- a/docs/PLATFORM_V2_DESIGN.md
+++ b/docs/PLATFORM_V2_DESIGN.md
@@ -1,0 +1,73 @@
+# StreamSense Platform v2 — Design
+
+> Status: **in progress** (foundation). Branch: `claude/streamsense-platform`.
+> Builds on the stabilized base (PR #21).
+
+## Goal
+
+A single, modern control surface to run a personal multi-modal research rig:
+
+| Modality | Device | Mode | Transport |
+|----------|--------|------|-----------|
+| EEG/PPG/ACC/GYRO | **Muse S** | **live** | BLE (`muselsl`/`pygatt`) → LSL |
+| ECG/EDA/EMG/EEG/ACC | **BITalino** | **live** | BLE/serial (`bitalino`) → LSL |
+| Body/skeleton + IMU; RGB/depth video | **Azure Kinect** | **live** | `pyk4a` + Body Tracking SDK → LSL (joints/IMU) + `.mkv` sidecar + sync markers |
+| BVP/EDA/HR/IBI/TEMP/ACC/tags | **Empatica E4** | **import only** | Empatica withdrew the streaming server → no live path; import E4 Connect session archives post-hoc |
+
+LSL remains the live bus; the recorder writes the synchronized session.
+
+## Architecture
+
+```
+                +-------------------+        WebSocket (live status)
+   Browser  <-->|  Web frontend     |<--------------------------+
+   (Vite/React) |  (frontend/)      |                           |
+                +---------+---------+                           |
+                          | REST (/api/*)                       |
+                +---------v-----------------------------+       |
+                |  FastAPI app (api/app.py)             |-------+
+                +---------+-----------------------------+
+                          | calls (framework-agnostic)
+                +---------v-----------------------------+
+                |  DeviceManager (core/device_manager)  |  <-- pure Python, unit-tested headless
+                |  - discover/connect/record/status     |
+                |  - EventBus (listeners)               |
+                +----+-------------------+--------------+
+                     | drivers (lazy hw imports)
+       +-------------+------+-------------+-----------------+
+       | MuseDriver | BitalinoDriver | KinectDriver(*) | E4ImportDriver |
+       +------------+----------------+-----------------+----------------+
+              \           \                |                 (import)
+               \           \               v
+                ` -> streamer.* (BaseStreamer subclasses) -> LSL -> StreamRecorder
+   (*) Kinect driver: PR-2
+```
+
+**Key principle:** `core/` never imports FastAPI or any hardware library at module load. Drivers
+import hardware deps *lazily* inside methods and report availability via `available()`, so the
+core + API import and test cleanly in a headless CI with no devices installed.
+
+## API surface (PR-1)
+
+- `GET  /api/health`
+- `GET  /api/devices` — known devices + state
+- `POST /api/discover` — `{types?: [...]}` → discovered devices
+- `POST /api/devices/{id}/connect` / `/disconnect`
+- `POST /api/recording/start` / `/stop`
+- `GET  /api/status` — system + recording + per-device
+- `GET  /api/streams` — active LSL streams
+- `WS   /ws` — live `device_update` / `recording` / `status` / `log` events
+
+## Honest constraints
+
+- **E4 is post-hoc only** (server withdrawn) — it cannot be part of the live synchronized capture; it is aligned by timestamps/tags after the fact.
+- **Signal quality** is reported as `null` until a real per-stream metric is implemented (no fabricated values).
+- Raw Kinect video is **not** pushed over LSL (bandwidth) — recorded to file + LSL sync markers.
+
+## PR series
+
+1. **Foundation (this PR):** `core/` device manager + drivers (Muse/BITalino real, Kinect/E4 declared) + FastAPI API + headless tests + web frontend scaffold.
+2. **Kinect streamer:** `pyk4a` joints/IMU → LSL, `.mkv` + sync markers, recorder sidecar.
+3. **E4 importer:** parse E4 Connect archives → align into session dataset.
+4. **Acquisition optimization:** event/queue handshakes (remove `time.sleep` sync), reconnect/backoff, unified clock, real signal-quality.
+5. **Frontend build-out:** device cards, signal quality, stream monitor, Kinect preview, session manager.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.local
+.vite/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,28 @@
+# StreamSense Frontend (Platform v2)
+
+Vite + React + TypeScript web UI for the StreamSense platform. Talks to the FastAPI
+backend (`api/app.py`) over REST (`/api/*`) and a WebSocket (`/ws`).
+
+## Run (development)
+
+```bash
+# 1) Backend (from repo root)
+pip install -r requirements-dev.txt          # or: pip install fastapi "uvicorn[standard]"
+uvicorn api.app:app --reload --port 8000
+
+# 2) Frontend (this folder)
+npm install
+npm run dev          # http://localhost:5173  (proxies /api and /ws to :8000)
+```
+
+## Build / typecheck
+
+```bash
+npm run build        # tsc -b && vite build  -> dist/
+npm run typecheck
+```
+
+## Layout
+
+- `src/api.ts` — typed REST client + WebSocket helper
+- `src/App.tsx` — dashboard (discover, connect/disconnect, recording, live status, modality availability, activity log)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>StreamSense</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,1732 @@
+{
+  "name": "streamsense-frontend",
+  "version": "2.0.0-dev",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "streamsense-frontend",
+      "version": "2.0.0-dev",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.11"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.363",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
+      "integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "streamsense-frontend",
+  "private": true,
+  "version": "2.0.0-dev",
+  "type": "module",
+  "description": "StreamSense Platform v2 web UI (Vite + React + TypeScript)",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  api, connectWebSocket,
+  type Device, type SystemStatus, type WsEvent,
+} from "./api";
+
+const DEVICE_ICON: Record<string, string> = {
+  muse: "🧠", bitalino: "💓", kinect: "🎥", e4: "⌚",
+};
+
+export default function App() {
+  const [status, setStatus] = useState<SystemStatus | null>(null);
+  const [log, setLog] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try { setStatus(await api.status()); } catch (e) { pushLog(`status error: ${e}`); }
+  }, []);
+
+  const pushLog = (line: string) =>
+    setLog((l) => [`${new Date().toLocaleTimeString()}  ${line}`, ...l].slice(0, 100));
+
+  useEffect(() => {
+    refresh();
+    const ws = connectWebSocket((e: WsEvent) => {
+      if (e.type === "status") setStatus(e.payload as SystemStatus);
+      else if (e.type === "device_update") refresh();
+      else if (e.type === "recording") refresh();
+      else if (e.type === "log") {
+        const p = e.payload as { level: string; message: string };
+        pushLog(`[${p.level}] ${p.message}`);
+      }
+    });
+    ws.onclose = () => pushLog("websocket closed");
+    return () => ws.close();
+  }, [refresh]);
+
+  const run = async (label: string, fn: () => Promise<unknown>) => {
+    setBusy(true);
+    try { await fn(); pushLog(label); } catch (e) { pushLog(`${label} failed: ${e}`); }
+    finally { setBusy(false); await refresh(); }
+  };
+
+  const rec = status?.recording;
+
+  return (
+    <div className="app">
+      <header>
+        <h1>🧠 StreamSense</h1>
+        <span className="subtitle">Multi-Device Recording Platform</span>
+      </header>
+
+      <section className="controls">
+        <button disabled={busy} onClick={() => run("discover", () => api.discover())}>
+          🔍 Discover devices
+        </button>
+        {rec?.active ? (
+          <button className="rec stop" disabled={busy}
+            onClick={() => run("stop recording", api.stopRecording)}>
+            ⏹ Stop recording
+          </button>
+        ) : (
+          <button className="rec start" disabled={busy}
+            onClick={() => run("start recording", api.startRecording)}>
+            🔴 Start recording
+          </button>
+        )}
+        {rec?.active && <span className="session">● {rec.session_id}</span>}
+      </section>
+
+      <section className="grid">
+        <div className="panel">
+          <h2>Devices</h2>
+          {(status?.devices ?? []).length === 0 && <p className="muted">No devices yet — discover.</p>}
+          {(status?.devices ?? []).map((d) => (
+            <DeviceCard key={d.id} d={d} busy={busy}
+              onConnect={() => run(`connect ${d.name}`, () => api.connect(d.id))}
+              onDisconnect={() => run(`disconnect ${d.name}`, () => api.disconnect(d.id))} />
+          ))}
+        </div>
+
+        <div className="panel">
+          <h2>Modalities</h2>
+          {Object.entries(status?.driver_availability ?? {}).map(([t, a]) => (
+            <div key={t} className="modality">
+              <span>{DEVICE_ICON[t] ?? "📟"} {t}</span>
+              <span className={a.available ? "ok" : "off"}>
+                {a.available ? "available" : (a.live ? "unavailable" : "import-only")}
+              </span>
+              {!a.available && <small className="muted">{a.reason}</small>}
+            </div>
+          ))}
+        </div>
+
+        <div className="panel">
+          <h2>Activity</h2>
+          <pre className="log">{log.join("\n")}</pre>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function DeviceCard({ d, busy, onConnect, onDisconnect }: {
+  d: Device; busy: boolean; onConnect: () => void; onDisconnect: () => void;
+}) {
+  const connected = d.state === "connected";
+  return (
+    <div className={`device ${d.state}`}>
+      <div className="device-head">
+        <span>{DEVICE_ICON[d.type] ?? "📟"} <strong>{d.name}</strong></span>
+        <span className={`badge ${d.state}`}>{d.state}</span>
+      </div>
+      <div className="device-meta">
+        <span className="muted">{d.address}</span>
+        <span>SQ: {d.signal_quality == null ? "—" : `${Math.round(d.signal_quality * 100)}%`}</span>
+      </div>
+      {connected ? (
+        <button disabled={busy} onClick={onDisconnect}>Disconnect</button>
+      ) : (
+        <button disabled={busy} onClick={onConnect}>Connect</button>
+      )}
+      {d.detail && <small className="muted">{d.detail}</small>}
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,68 @@
+// Typed client for the StreamSense Platform API.
+
+export type ConnectionState =
+  | "discovered" | "connecting" | "connected"
+  | "disconnecting" | "disconnected" | "error";
+
+export interface Device {
+  id: string;
+  name: string;
+  type: string;
+  address: string;
+  state: ConnectionState;
+  signal_quality: number | null;
+  detail: string | null;
+  streams: string[];
+}
+
+export interface RecordingState {
+  active: boolean;
+  session_id: string | null;
+  output_folder: string | null;
+  started_at: number | null;
+}
+
+export interface DriverAvailability {
+  available: boolean;
+  reason: string;
+  live: boolean;
+}
+
+export interface SystemStatus {
+  devices: Device[];
+  recording: RecordingState;
+  driver_availability: Record<string, DriverAvailability>;
+}
+
+async function jpost<T>(path: string, body?: unknown): Promise<T> {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) throw new Error((await res.json()).detail ?? res.statusText);
+  return res.json();
+}
+
+export const api = {
+  status: (): Promise<SystemStatus> => fetch("/api/status").then((r) => r.json()),
+  discover: (types?: string[]): Promise<Device[]> => jpost("/api/discover", { types }),
+  connect: (id: string) => jpost(`/api/devices/${encodeURIComponent(id)}/connect`),
+  disconnect: (id: string) => jpost(`/api/devices/${encodeURIComponent(id)}/disconnect`),
+  startRecording: () => jpost("/api/recording/start"),
+  stopRecording: () => jpost("/api/recording/stop"),
+};
+
+// Live event stream over WebSocket.
+export interface WsEvent {
+  type: "status" | "device_update" | "recording" | "log";
+  payload: unknown;
+  ts: number;
+}
+
+export function connectWebSocket(onEvent: (e: WsEvent) => void): WebSocket {
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  const ws = new WebSocket(`${proto}://${location.host}/ws`);
+  ws.onmessage = (m) => onEvent(JSON.parse(m.data));
+  return ws;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,38 @@
+:root {
+  --bg: #0f1419; --panel: #1a212b; --line: #2a3441;
+  --fg: #e6edf3; --muted: #8b98a5; --accent: #4a9eff;
+  --ok: #3fb950; --off: #f85149; --warn: #d29922;
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--fg);
+  font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+.app { max-width: 1200px; margin: 0 auto; padding: 24px; }
+header { display: flex; align-items: baseline; gap: 12px; margin-bottom: 20px; }
+header h1 { margin: 0; font-size: 28px; }
+.subtitle { color: var(--muted); }
+.controls { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+button { background: var(--accent); color: white; border: 0; border-radius: 8px;
+  padding: 10px 16px; font-size: 14px; cursor: pointer; }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+button.rec.start { background: var(--off); }
+button.rec.stop { background: var(--warn); }
+.session { color: var(--off); font-weight: 600; }
+.grid { display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: 16px; }
+.panel { background: var(--panel); border: 1px solid var(--line);
+  border-radius: 12px; padding: 16px; }
+.panel h2 { margin: 0 0 12px; font-size: 16px; }
+.muted { color: var(--muted); }
+.device { border: 1px solid var(--line); border-radius: 10px; padding: 12px; margin-bottom: 10px; }
+.device.connected { border-color: var(--ok); }
+.device.error { border-color: var(--off); }
+.device-head, .device-meta { display: flex; justify-content: space-between; align-items: center; }
+.device-meta { margin: 6px 0 10px; font-size: 12px; }
+.badge { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--line); }
+.badge.connected { background: var(--ok); color: #06210f; }
+.badge.error { background: var(--off); color: #2a0a08; }
+.modality { display: flex; flex-direction: column; padding: 8px 0; border-bottom: 1px solid var(--line); }
+.modality > span:first-child { display: flex; justify-content: space-between; }
+.ok { color: var(--ok); } .off { color: var(--off); }
+.log { background: #0b0f14; border-radius: 8px; padding: 10px; height: 320px;
+  overflow: auto; font-size: 12px; white-space: pre-wrap; color: var(--muted); }
+@media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.tsbuildinfo
+++ b/frontend/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/App.tsx","./src/api.ts","./src/main.tsx"],"version":"5.9.3"}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Dev server proxies API + WebSocket to the FastAPI backend on :8000.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": { target: "http://localhost:8000", changeOrigin: true },
+      "/ws": { target: "ws://localhost:8000", ws: true },
+    },
+  },
+});

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,12 @@ bitstring==4.4.0
 pylsl==1.18.2
 mne==1.12.1
 
+# Platform web backend (FastAPI API + WebSocket) — needed to run core/api tests
+fastapi==0.136.3
+uvicorn==0.48.0
+httpx==0.28.1
+pydantic==2.13.4
+
 # Test tooling
 pytest==9.0.3
 pytest-cov==7.1.0

--- a/tests/platform_mocks.py
+++ b/tests/platform_mocks.py
@@ -1,0 +1,62 @@
+"""Shared mocks for platform (core + api) tests — no hardware, no real LSL."""
+
+import threading
+
+from core import DeviceManager, DeviceType, DeviceInfo
+from core.drivers import DeviceDriver
+
+
+class MockStreamer:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.stopped = False
+
+    def start_streaming(self, timeout: int = 15) -> bool:
+        return not self.fail
+
+    def stop_streaming(self) -> None:
+        self.stopped = True
+
+
+class MockDriver(DeviceDriver):
+    live = True
+
+    def __init__(self, dtype=DeviceType.MUSE, devices=None, fail=False, available=True):
+        self.device_type = dtype
+        self._devices = devices if devices is not None else [
+            DeviceInfo(id="muse:AA", name="Muse-AA", type=DeviceType.MUSE, address="AA")
+        ]
+        self.fail = fail
+        self._available = available
+
+    def available(self):
+        return (self._available, "" if self._available else "mock unavailable")
+
+    def discover(self):
+        return [DeviceInfo(**{**d.__dict__}) for d in self._devices]
+
+    def create_streamer(self, device, output_folder, sync_time):
+        return MockStreamer(fail=self.fail)
+
+
+class MockRecorder:
+    def __init__(self, output_folder):
+        self.output_folder = output_folder
+        self.started_event = threading.Event()
+        self._stop = threading.Event()
+
+    def record_streams(self):
+        self.started_event.set()
+        self._stop.wait()
+
+    def stop(self):
+        self._stop.set()
+
+
+def make_manager(fail=False, devices=None, available=True):
+    drv = MockDriver(devices=devices, fail=fail, available=available)
+    return DeviceManager(
+        drivers={DeviceType.MUSE: drv},
+        output_root="/tmp/ss_platform_test",
+        recorder_factory=lambda f: MockRecorder(f),
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,76 @@
+"""Headless API tests using FastAPI's TestClient (REST + WebSocket), mock manager."""
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from api.app import create_app
+from tests.platform_mocks import make_manager
+
+
+def _client():
+    return TestClient(create_app(manager=make_manager()))
+
+
+def test_health():
+    c = _client()
+    r = c.get("/api/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_discover_then_list_devices():
+    c = _client()
+    r = c.post("/api/discover", json={"types": ["muse"]})
+    assert r.status_code == 200
+    assert [d["id"] for d in r.json()] == ["muse:AA"]
+
+    r2 = c.get("/api/devices")
+    assert any(d["id"] == "muse:AA" for d in r2.json())
+
+
+def test_connect_and_disconnect_flow():
+    c = _client()
+    c.post("/api/discover", json={})
+    r = c.post("/api/devices/muse:AA/connect")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["device"]["state"] == "connected"
+
+    r2 = c.post("/api/devices/muse:AA/disconnect")
+    assert r2.json()["device"]["state"] == "disconnected"
+
+
+def test_connect_unknown_device_returns_400():
+    c = _client()
+    r = c.post("/api/devices/ghost/connect")
+    assert r.status_code == 400
+
+
+def test_recording_endpoints():
+    c = _client()
+    r = c.post("/api/recording/start")
+    assert r.json()["recording"]["active"] is True
+    r2 = c.post("/api/recording/stop")
+    assert r2.json()["recording"]["active"] is False
+
+
+def test_status_endpoint_shape():
+    c = _client()
+    r = c.get("/api/status")
+    body = r.json()
+    assert "devices" in body and "recording" in body and "driver_availability" in body
+
+
+def test_websocket_receives_initial_status_and_live_event():
+    mgr = make_manager()
+    client = TestClient(create_app(manager=mgr))
+    with client.websocket_connect("/ws") as ws:
+        first = ws.receive_json()
+        assert first["type"] == "status"
+        # Emit a device event from the test thread; the listener hops it onto the loop.
+        mgr.discover(["muse"])
+        msg = ws.receive_json()
+        assert msg["type"] in ("device_update", "log")

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -1,0 +1,79 @@
+"""Headless unit tests for core.DeviceManager (mock drivers/recorder, no hardware)."""
+
+import pytest
+
+from core import DeviceManager, DeviceType, ConnectionState, DeviceInfo, DeviceManagerError
+from core.drivers import E4ImportDriver
+from tests.platform_mocks import make_manager
+
+
+def test_discover_adds_devices_and_emits_events():
+    events = []
+    m = make_manager()
+    m.add_listener(events.append)
+    found = m.discover(["muse"])
+    assert [d.id for d in found] == ["muse:AA"]
+    assert "muse:AA" in m.devices
+    assert any(e["type"] == "device_update" for e in events)
+
+
+def test_connect_success_marks_connected():
+    m = make_manager()
+    m.discover()
+    assert m.connect("muse:AA") is True
+    assert m.devices["muse:AA"].state == ConnectionState.CONNECTED
+
+
+def test_connect_failure_marks_error():
+    m = make_manager(fail=True)
+    m.discover()
+    assert m.connect("muse:AA") is False
+    assert m.devices["muse:AA"].state == ConnectionState.ERROR
+
+
+def test_disconnect_stops_streamer_and_updates_state():
+    m = make_manager()
+    m.discover()
+    m.connect("muse:AA")
+    streamer = m._streamers["muse:AA"]
+    assert m.disconnect("muse:AA") is True
+    assert streamer.stopped is True
+    assert m.devices["muse:AA"].state == ConnectionState.DISCONNECTED
+    assert "muse:AA" not in m._streamers
+
+
+def test_unknown_device_raises():
+    m = make_manager()
+    with pytest.raises(DeviceManagerError):
+        m.connect("does-not-exist")
+
+
+def test_import_only_driver_cannot_connect_live():
+    m = DeviceManager(drivers={DeviceType.E4: E4ImportDriver()}, output_root="/tmp/ss")
+    m.devices["e4:x"] = DeviceInfo(id="e4:x", name="E4", type=DeviceType.E4, address="x")
+    with pytest.raises(DeviceManagerError):
+        m.connect("e4:x")
+
+
+def test_recording_lifecycle():
+    m = make_manager()
+    assert m.start_recording(timeout=5) is True
+    assert m.recording.active is True
+    assert m.recording.session_id
+    assert m.stop_recording() is True
+    assert m.recording.active is False
+
+
+def test_status_reports_driver_availability_and_no_fake_quality():
+    m = make_manager()
+    m.discover()
+    status = m.get_status().to_dict()
+    assert "muse" in status["driver_availability"]
+    assert status["recording"]["active"] is False
+    # Honest: signal quality is unknown (None), never a fabricated number.
+    assert status["devices"][0]["signal_quality"] is None
+
+
+def test_unavailable_driver_is_skipped_in_discovery():
+    m = make_manager(available=False)
+    assert m.discover(["muse"]) == []


### PR DESCRIPTION
## What this is

First PR of the **integrated multi-modal rig**: one modern control surface for
**Azure Kinect + Muse S + BITalino** (live) with **Empatica E4 as offline import**
(Empatica withdrew the E4 streaming server, so live E4 is no longer possible).

> Stacked on the stabilization work — **base is `claude/determined-gates-Zkfw7` (PR #21)**, so this diff is platform-only. Merge #21 first (or after), then this can retarget `master`.

Full design: `docs/PLATFORM_V2_DESIGN.md`.

## Backend (framework-agnostic, headless-testable)
- **`core/`** — `DeviceManager` (discover / connect / disconnect / record / status + an event bus) and a **driver layer with lazy hardware imports**. `core/` imports **no FastAPI and no device SDK** at module load; drivers import `muselsl`/`pygatt`/`bitalino`/`pyk4a` *inside* methods and report `available()`, so everything imports and tests in a headless CI with no devices.
  - Muse + BITalino: real drivers. Kinect: placeholder (PR-2). E4: import-only driver (PR-3).
  - **Signal quality is reported as `null`** until a real metric exists — no fabricated values (fixes a debt item from the audit).
- **`api/`** — FastAPI app: REST `/api/*` + a `/ws` WebSocket that bridges manager events onto the event loop via `call_soon_threadsafe`.

## Frontend
- **`frontend/`** — Vite + React + TypeScript dashboard: discover, connect/disconnect, recording controls, **live status over WebSocket**, modality-availability panel, activity log. `tsc` (strict) + `vite build` both pass.

## Tests (headless, no hardware)
- `tests/test_device_manager.py` (9) + `tests/test_api.py` (REST + WebSocket via `TestClient`), shared mocks in `tests/platform_mocks.py`.
- **Full suite: 141 passed, 7 skipped, exits cleanly.** Frontend: `npm run build` green.
- `requirements-dev.txt` extended with `fastapi/uvicorn/httpx/pydantic` so CI runs the new tests.

## Honest constraints (carried from the device realities)
- **E4 = post-hoc import only** — cannot join the live synchronized capture.
- **Kinect raw video** will be recorded to `.mkv` + LSL sync markers (not pushed over LSL); joints/IMU go to LSL. (PR-2)

## Next in the series
PR-2 Kinect streamer (`pyk4a` joints/IMU + video sidecar) · PR-3 E4 importer · PR-4 acquisition optimization (remove `time.sleep` sync, reconnect/backoff, unified clock, real signal-quality) · PR-5 frontend build-out.

https://claude.ai/code/session_01T2MnB3hcijafcgbwfzBt6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2MnB3hcijafcgbwfzBt6m)_